### PR TITLE
Updatet to ndarray 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 std = ["nalgebra/std"]
 
 [dependencies]
-ndarray = { version = "0.14.0", default-features = false, optional = true }
+ndarray = { version = "0.15.0", default-features = false, optional = true }
 nalgebra = { version = "0.23.1", default-features = false, optional = true }
 image = { version = "0.23.12", default-features = false, optional = true }
 


### PR DESCRIPTION
I updatet to ndarray 0.15.0.
(Just a little hint to the maintainers: If you enable Dependabot, you don't have to do this manually, but my Dependabot won't run into issues, when ndarray is updated.)