### PR TITLE
fix: numpy compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ndarray = ["dep:ndarray", "alloc"]
 image = ["dep:image", "alloc"]
 
 [dependencies]
-ndarray = { version = "0.16", default-features = false, optional = true }
+ndarray = { version = "0.15", default-features = false, optional = true }
 nalgebra = { version = "0.33", default-features = false, optional = true }
 image = { version = "0.25", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nshare"
-version = "0.10.0"
+version = "0.9.1"
 authors = ["Geordon Worley <vadixidav@gmail.com>"]
 edition = "2021"
 description = "Conversion between n-dimensional types in different Rust crates"


### PR DESCRIPTION
Unfortunately, numpy does not currently work with ndarray 0.16 as seen [here](https://github.com/PyO3/rust-numpy/pull/439). 

Since 0.9.0 version is using an older version of `image` crate - I have decided to fork this for the time being. 

Please let me know if we could perhaps release this as `0.10.0-numpy-compat` or similar to avoid having to supply a git dependency. Then I'll make appropriate changes to `Cargo.toml`. 